### PR TITLE
menu API: 'GET /api/menu'でメニューの一覧を表示する

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class MenuController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -14,7 +14,7 @@ class MenuController extends Controller
     // TODO: リソースコントローラを使ってリファクタリング
 
     /**
-     *
+     * 認証されたお客さんに、滞在している店のメニュー一覧を提供する
      */
     public function getAll(Request $request): Collection
     {

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -2,9 +2,22 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Menu;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 
 class MenuController extends Controller
 {
-    //
+    // TODO: リソースコントローラを使ってリファクタリング
+
+    /**
+     *
+     */
+    public function getAll(): Collection
+    {
+        $model_query = Menu::query();
+        $menus = $model_query->get();
+
+        return $menus;
+    }
 }

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -29,7 +29,7 @@ class MenuController extends Controller
 
 
         $model_query = Menu::query()
-            ->where('restaurant_id', $party->value('restaurant_id'));
+            ->where('restaurant_id', $party->restaurant_id);
         $menus = $model_query->get();
 
         return $menus;

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -23,11 +23,6 @@ class MenuController extends Controller
             ->where('uuid', $session_secret)
             ->first();
 
-        if ($party == null) {
-            throw new HttpException(Response::HTTP_FORBIDDEN);
-        }
-
-
         $model_query = Menu::query()
             ->where('restaurant_id', $party->restaurant_id);
         $menus = $model_query->get();

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -3,8 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Menu;
+use App\Models\Party;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class MenuController extends Controller
 {
@@ -13,9 +16,20 @@ class MenuController extends Controller
     /**
      *
      */
-    public function getAll(): Collection
+    public function getAll(Request $request): Collection
     {
-        $model_query = Menu::query();
+        $session_secret = $request->cookie('session_secret');
+        $party = Party::query()
+            ->where('uuid', $session_secret)
+            ->first();
+
+        if ($party == null) {
+            throw new HttpException(Response::HTTP_FORBIDDEN);
+        }
+
+
+        $model_query = Menu::query()
+            ->where('restaurant_id', $party->value('restaurant_id'));
         $menus = $model_query->get();
 
         return $menus;

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PartyController extends Controller
+{
+    // TODO: party APIを実装
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,7 @@ class Kernel extends HttpKernel
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\Authorise::class,
         ],
     ];
 

--- a/app/Http/Middleware/Authorise.php
+++ b/app/Http/Middleware/Authorise.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Party;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class Authorise
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $session_secret = $request->cookie('session_secret');
+        $party = Party::query()
+            ->where('uuid', $session_secret)
+            ->first();
+
+        if ($party == null) {
+            throw new HttpException(Response::HTTP_FORBIDDEN);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/Authorise.php
+++ b/app/Http/Middleware/Authorise.php
@@ -24,7 +24,7 @@ class Authorise
             ->where('uuid', $session_secret)
             ->first();
 
-        if ($party == null) {
+        if (is_null($party)) {
             throw new HttpException(Response::HTTP_FORBIDDEN);
         }
 

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Menu extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class Menu extends Model
 {
     use HasFactory;
+
+    /**
+     * モデルの属性のデフォルト値
+     *
+     * @var null[]
+     */
+    protected $attributes = [
+        'image_url' => null
+    ];
 }

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Party extends Model
+{
+    use HasFactory;
+
+    /**
+     * モデルの属性のデフォルト値
+     * @var int[]
+     */
+    protected $attributes = [
+        'state' => 0,
+    ];
+}

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Restaurant extends Model
+{
+    use HasFactory;
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Menu;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MenuFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Menu::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -22,7 +22,10 @@ class MenuFactory extends Factory
     public function definition()
     {
         return [
-            //
+            'restaurant_id' => 0,
+            'name' => $this->faker->name(),
+            'price' => $this->faker->numberBetween(0, 1000),
+            'image_url' => $this->faker->imageUrl()
         ];
     }
 }

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Menu;
+use App\Models\Restaurant;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class MenuFactory extends Factory
@@ -21,8 +22,9 @@ class MenuFactory extends Factory
      */
     public function definition()
     {
+        $restaurant_ids = Restaurant::all()->pluck('id');
         return [
-            'restaurant_id' => $this->faker->numberBetween(1,3),
+            'restaurant_id' => $this->faker->randomElement($restaurant_ids),
             'name' => $this->faker->name(),
             'price' => $this->faker->numberBetween(0, 1000),
             'image_url' => $this->faker->imageUrl()

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -22,7 +22,7 @@ class MenuFactory extends Factory
     public function definition()
     {
         return [
-            'restaurant_id' => 0,
+            'restaurant_id' => $this->faker->numberBetween(1,3),
             'name' => $this->faker->name(),
             'price' => $this->faker->numberBetween(0, 1000),
             'image_url' => $this->faker->imageUrl()

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -22,8 +22,9 @@ class PartyFactory extends Factory
      */
     public function definition()
     {
+        $restaurant_ids = Restaurant::all()->pluck('id');
         return [
-            'restaurant_id' => $this->faker->numberBetween(1,3),
+            'restaurant_id' => $this->faker->randomElement($restaurant_ids),
             'state' => 0,
             'uuid' => $this->faker->unique()->uuid(),
         ];

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Party;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PartyFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Party::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'restaurant_id' => 0,
+            'state' => 0,
+            'uuid' => $this->faker->unique()->uuid(),
+        ];
+    }
+}

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Party;
+use App\Models\Restaurant;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class PartyFactory extends Factory
@@ -22,7 +23,7 @@ class PartyFactory extends Factory
     public function definition()
     {
         return [
-            'restaurant_id' => 0,
+            'restaurant_id' => $this->faker->numberBetween(1,3),
             'state' => 0,
             'uuid' => $this->faker->unique()->uuid(),
         ];

--- a/database/factories/RestaurantFactory.php
+++ b/database/factories/RestaurantFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Restaurant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+
+class RestaurantFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Restaurant::class;
+
+    /**
+     * ユーザ（お店）の課金が切れていることを示す
+     * 
+     * @return RestaurantFactory
+     */
+    public function expired()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'expired_date' => $this->faker->date('2000-1-1'),
+            ];
+        });
+    }
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'expired_date' => $this->faker->date('2121-9-15'),
+            'pass_hash' => Hash::make('yumemi2021'),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ class DatabaseSeeder extends Seeder
 {
     /**
      * Seed the application's database.
+     * お勧めコマンド: 'sail artisan migrate:fresh --seed'
      *
      * @return void
      */

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,7 +8,7 @@ class DatabaseSeeder extends Seeder
 {
     /**
      * Seed the application's database.
-     * お勧めコマンド: 'sail artisan migrate:fresh --seed'
+     * お勧めコマンド: 'sail artisan migrate:refresh --seed'
      *
      * @return void
      */

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        $this->call([
+            RestaurantSeeder::class,
+            PartySeeder::class,
+            MenuSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class MenuSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use App\Models\Menu;
 
 class MenuSeeder extends Seeder
 {
@@ -13,6 +14,8 @@ class MenuSeeder extends Seeder
      */
     public function run()
     {
-        //
+        Menu::factory()
+            ->count(10)
+            ->create();
     }
 }

--- a/database/seeders/PartySeeder.php
+++ b/database/seeders/PartySeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Party;
+
+class PartySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Party::factory()
+            ->count(3)
+            ->create();
+    }
+}

--- a/database/seeders/RestaurantSeeder.php
+++ b/database/seeders/RestaurantSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Restaurant;
+use Illuminate\Database\Seeder;
+
+class RestaurantSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // 課金の切れていない（利用可能な）店舗1件をDBに追加
+        Restaurant::factory()
+            ->create();
+        // 課金の切れた（利用不可能な）店舗1件をDBに追加
+        Restaurant::factory()
+            ->expired()
+            ->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,8 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
+//Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+//    return $request->user();
+//});
+
+Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll']);

--- a/tests/Feature/MenuTest.php
+++ b/tests/Feature/MenuTest.php
@@ -17,7 +17,7 @@ class MenuTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        Artisan::call('migrate:refresh --seed');
+        $this->seed();
     }
 
     /**

--- a/tests/Feature/MenuTest.php
+++ b/tests/Feature/MenuTest.php
@@ -44,7 +44,7 @@ class MenuTest extends TestCase
         $response->assertStatus(200);
 
         // 返答したデータがあっているかどうか
-        $menus = Menu::query()->where('restaurant_id', $party->value('restaurant_id'))
+        $menus = Menu::query()->where('restaurant_id', $party->restaurant_id)
             ->get();
         $response->assertSimilarJson($menus->jsonSerialize());
     }

--- a/tests/Feature/MenuTest.php
+++ b/tests/Feature/MenuTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Menu;
+use App\Models\Party;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class MenuTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Artisan::call('migrate:refresh --seed');
+    }
+
+    /**
+     * session_secretの指定がない時は認可失敗になる
+     *
+     * @return void
+     */
+    public function test_認可失敗_403が返ってくる()
+    {
+        $response = $this->get('/api/menu');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_認可成功_200が返ってくる_店舗ごとに違ったメニューが帰ってくる()
+    {
+        $party = Party::query()->find(1);
+        $uuid = $party->value('uuid');
+        $cookie = ['session_secret' => $uuid];
+        // cookieは暗号化しない
+        $response = $this->call('get', '/api/menu', [], $cookie);
+
+        // HTTP status 200
+        $response->assertStatus(200);
+
+        // 返答したデータがあっているかどうか
+        $menus = Menu::query()->where('restaurant_id', $party->value('restaurant_id'))
+            ->get();
+        $response->assertSimilarJson($menus->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## 実装した機能
- cookieの`session_secret`の値を使って、お客さんを認証する
- 認証されたお客さんが、`GET /api/menu`で自分のいる店のメニューの一覧を取得する

## 他に書いたコード
- `GET /api/menu`のテスト
   - 認証失敗時に403が返ること
   - 認証成功時に200が返り、正しいデータ（メニューの一覧）を返していること
- シーディング
   - restaurant, menu, partyのモデル、ファクトリーおよびシーダ