### PR TITLE
menu API: `DELETE /api/menu` メニューの削除

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\DeleteMenuRequest;
 use App\Http\Requests\StoreMenuRequest;
 use App\Models\Menu;
 use App\Models\Party;
+use App\Services\MenuService;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,17 +17,15 @@ class MenuController extends Controller
     // TODO: リソースコントローラを使ってリファクタリング
 
     /**
-     * 認証されたお客さんに、滞在している店のメニュー一覧を提供する
+     * お店の人に、店のメニュー一覧を提供する
      */
     public function getAll(Request $request): Collection
     {
-        $session_secret = $request->cookie('session_secret');
-        $party = Party::query()
-            ->where('uuid', $session_secret)
-            ->first();
+        // TODO: 店員さんであることの認証
+        $dummyRestaurantId = 1;
 
         $model_query = Menu::query()
-            ->where('restaurant_id', $party->restaurant_id);
+            ->where('restaurant_id', $dummyRestaurantId);
         $menus = $model_query->get();
 
         return $menus;
@@ -37,37 +36,23 @@ class MenuController extends Controller
      */
     public function store(StoreMenuRequest $request) {
         // TODO: 店員さんであることの認証
-
-        $session_secret = $request->cookie('session_secret');
-        $party = Party::query()
-            ->where('uuid', $session_secret)
-            ->first();
+        $dummyRestaurantId = 1;
 
         // validate request
         $validated = $request->validated();
 
-        // JSONであることを確認
-        if (!$request->expectsJson()) {
-            throw new HttpException(Response::HTTP_BAD_REQUEST);
-        }
-
-        $new_menu = new Menu;
-        $new_menu->restaurant_id = $party->restaurant_id;
-        $new_menu->name = $validated['name'];
-        $new_menu->price = $validated['price'];
-        $new_menu->image_url = $validated['image_url'];
-        $new_menu->save();
-
-        return $new_menu;
+        return MenuService::addNewMenu(
+            $dummyRestaurantId,
+            $validated['name'],
+            $validated['price'],
+            $validated['image_url'],
+        );
     }
 
     public function delete(DeleteMenuRequest $request)
     {
         // TODO: 店員さんの認証
-        $session_secret = $request->cookie('session_secret');
-        $party = Party::query()
-            ->where('uuid', $session_secret)
-            ->first();
+        $dummyRestaurantId = 1;
 
         // validate request
         $validated = $request->validated();
@@ -79,7 +64,7 @@ class MenuController extends Controller
             throw new HttpException(Response::HTTP_BAD_REQUEST);
         }
 
-        if ($target_menu->restaurant_id === $party->restaurant_id) {
+        if ($target_menu->restaurant_id === $dummyRestaurantId) {
             // メニューを削除
             $target_menu->delete();
             // 削除したメニューのレコードを返す

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,7 +43,6 @@ class Kernel extends HttpKernel
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\Authorise::class,
         ],
     ];
 
@@ -64,5 +63,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'auth.customer' => \App\Http\Middleware\AuthoriseCustomer::class,
+        'auth.business' => \App\Http\Middleware\AuthoriseBusiness::class,
     ];
 }

--- a/app/Http/Middleware/AuthoriseBusiness.php
+++ b/app/Http/Middleware/AuthoriseBusiness.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Restaurant;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * 店員さんの認証を行うミドルウェア
+ */
+class AuthoriseBusiness
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        // TODO: お店の人を認証する
+        // 仮実装：誰が来てもid=1のお店の人だと認証する
+        $restaurant = Restaurant::query()->find(1);
+
+        if (is_null($restaurant)) {
+            throw new HttpException(Response::HTTP_FORBIDDEN);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/AuthoriseCustomer.php
+++ b/app/Http/Middleware/AuthoriseCustomer.php
@@ -8,7 +8,10 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class Authorise
+/**
+ * 食べに来た人の認証を行うミドルウェア
+ */
+class AuthoriseCustomer
 {
     /**
      * Handle an incoming request.

--- a/app/Http/Requests/DeleteMenuRequest.php
+++ b/app/Http/Requests/DeleteMenuRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteMenuRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // TODO: 店員さんであることの認証
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'id' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -17,4 +17,13 @@ class Menu extends Model
     protected $attributes = [
         'image_url' => null
     ];
+
+    protected $fillable = [
+        'restaurant_id',
+        'name',
+        'price',
+        'image_url',
+    ];
+
+    protected $table = 'menus';
 }

--- a/app/Services/MenuService.php
+++ b/app/Services/MenuService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Menu;
+
+class MenuService
+{
+    public static function addNewMenu(
+        int    $restaurantId,
+        string $name,
+        int    $price,
+        string $imageUrl
+    )
+    {
+        return Menu::create([
+            'restaurant_id' => $restaurantId,
+            'name' => $name,
+            'price' => $price,
+            'image_url' => $imageUrl,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,6 @@ use Illuminate\Support\Facades\Route;
 //    return $request->user();
 //});
 
-Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll']);
-Route::post('/menu', [\App\Http\Controllers\MenuController::class, 'store']);
-Route::delete('/menu', [\App\Http\Controllers\MenuController::class, 'delete']);
+Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll'])->middleware('auth.business');
+Route::post('/menu', [\App\Http\Controllers\MenuController::class, 'store'])->middleware('auth.business');
+Route::delete('/menu', [\App\Http\Controllers\MenuController::class, 'delete'])->middleware('auth.business');

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll']);
 Route::post('/menu', [\App\Http\Controllers\MenuController::class, 'store']);
+Route::delete('/menu', [\App\Http\Controllers\MenuController::class, 'delete']);

--- a/tests/Feature/MenuTest.php
+++ b/tests/Feature/MenuTest.php
@@ -3,11 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Menu;
-use App\Models\Party;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
@@ -30,6 +26,7 @@ class MenuTest extends TestCase
 
     /**
      * テスト成功：session_secretの指定がないので、GETもPOSTも認可失敗&403が返ってくる
+     * AuthoriseBusinessの中身が未実装なので、このテストは成功しない
      */
     public function test_get_post_delete_認可失敗_403()
     {
@@ -51,21 +48,18 @@ class MenuTest extends TestCase
     }
 
     /**
-     * テスト成功：食べにきた人の滞在しているお店の全てのメニューが返ってくる&200が返ってくる
+     * テスト成功：お店の人のお店の全てのメニューが返ってくる&200が返ってくる
      */
-    public function test_get_認可成功_店舗ごとに違ったメニューが返ってくる_200()
+    public function test_get_認可成功_店舗1のメニューが全て返ってくる_200()
     {
-        $party = Party::query()->find(1);
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
-        // cookieは暗号化しない
-        $response = $this->call('get', '/api/menu', [], $cookie);
+        // TODO 認証情報を載せる
+        $response = $this->call('get', '/api/menu', [], []);
 
         // HTTP status 200
         $response->assertStatus(200);
 
         // 返答したデータがあっているかどうか
-        $menus = Menu::query()->where('restaurant_id', $party->restaurant_id)
+        $menus = Menu::query()->where('restaurant_id', 1)
             ->get();
         $response->assertSimilarJson($menus->jsonSerialize());
     }
@@ -75,12 +69,7 @@ class MenuTest extends TestCase
      */
     public function test_post_メニューを追加する_追加したメニューのレコードが帰ってくる_200()
     {
-        $party = Party::query()->find(1);
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
-
-        // cookieは暗号化しない
-        $response = $this->postJsonWithCookie('/api/menu', $cookie, MenuTest::$new_menu);
+        $response = $this->postJsonWithCookie('/api/menu', [], MenuTest::$new_menu);
 
         // HTTP status 201 created
         $response->assertStatus(Response::HTTP_CREATED)
@@ -93,17 +82,13 @@ class MenuTest extends TestCase
      */
     public function test_post_バリデーション違反_メニュー追加失敗_422()
     {
-        $party = Party::query()->find(1);
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
-
         $new_menu = [
             'name' => '追加できないハンバーグ',
             'price' => '-100',
             'image_url' => 'https://pbs.twimg.com/media/EsK3YCMVgAUJ2yb?format=jpg&name=large',
         ];
 
-        $this->postJsonWithCookie('/api/menu', $cookie, $new_menu)
+        $this->postJsonWithCookie('/api/menu', [], $new_menu)
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
@@ -112,21 +97,18 @@ class MenuTest extends TestCase
      */
     public function test_delete_メニューを削除する_削除したメニューのレコードが帰ってくる_200()
     {
-        $target = Menu::query()->find(1);
-
-        $party = Party::query()
-            ->where('restaurant_id', $target->restaurant_id)
+        $target = Menu::query()
+            ->where('restaurant_id', 1)
             ->first();
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
+        $targetId = $target->id;
 
-        $this->deleteJsonWithCookie('/api/menu', $cookie, [
+        $this->deleteJsonWithCookie('/api/menu', [], [
             'id' => $target->id,
         ])
             ->assertStatus(Response::HTTP_OK)
             ->assertJson($target->jsonSerialize());
 
-        self::assertNull(Menu::query()->find(1));
+        self::assertNull(Menu::query()->find($targetId));
     }
 
     /**
@@ -134,14 +116,10 @@ class MenuTest extends TestCase
      */
     public function test_delete_存在しないメニューの削除を試みる_400()
     {
-        $party = Party::query()->find(1);
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
-
         // 存在しないメニューを指定
         $delete_menu = ['id' => 20210916];
 
-        $this->deleteJsonWithCookie('/api/menu', $cookie, $delete_menu)
+        $this->deleteJsonWithCookie('/api/menu', [], $delete_menu)
             ->assertStatus(Response::HTTP_BAD_REQUEST);
     }
 
@@ -150,18 +128,11 @@ class MenuTest extends TestCase
      */
     public function test_delete_他店のメニューの削除を試みる_403()
     {
-        // 店舗1の適当なメニューを1件取得
-        $target = Menu::query()->where('restaurant_id', 1)->first();
-
-        // 店舗2のcookieを取得
-        $party = Party::query()
-            ->where('restaurant_id', 2)
-            ->first();
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
+        // 店舗2の適当なメニューを1件取得
+        $target = Menu::query()->where('restaurant_id', 2)->first();
 
         // よその店のメニューを削除するリクエストを送る
-        $this->deleteJsonWithCookie('/api/menu', $cookie, [
+        $this->deleteJsonWithCookie('/api/menu', [], [
             'id' => $target->id,
         ])
             ->assertStatus(Response::HTTP_FORBIDDEN);
@@ -172,14 +143,10 @@ class MenuTest extends TestCase
      */
     public function test_delete_バリデーション違反_422()
     {
-        $party = Party::query()->find(1);
-        $uuid = $party->uuid;
-        $cookie = ['session_secret' => $uuid];
-
         // バリデーション違反のidを指定
         $delete_menu = ['id' => -1];
 
-        $this->deleteJsonWithCookie('/api/menu', $cookie, $delete_menu)
+        $this->deleteJsonWithCookie('/api/menu', [], $delete_menu)
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 


### PR DESCRIPTION
### 実装した機能
- 「食べにきた人」が、`DELETE /api/menu`で滞在している店のメニューを削除する
   - 「店員さん」用のAPIでは? -> 店員さんの認証の実装が優先度低となっているため、今のところこの実装になっています

### 未実装の機能
- 「店員さん」の認証

### テスト
- 認証失敗時に403が返ること
- 削除成功時に200が返り、削除したメニューのレコードが返ること
- 存在しないメニューを削除しようとした時、400が返ること
- 他店のメニューを削除しようとした時、403が返ること
- バリデーションに違反するリクエストを送信した時、422が返ること