### PR TITLE
menubook API: 食べる人用 `GET /api/menubook`で滞在している店のメニュー一覧を取得

### DIFF
--- a/app/Http/Controllers/MenubookController.php
+++ b/app/Http/Controllers/MenubookController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\MenubookResource;
 use App\Models\Party;
 use App\Services\MenuService;
 use Illuminate\Http\Request;
@@ -22,6 +23,8 @@ class MenubookController extends Controller
         /* @var Party $party */
         $party = Auth::user();
 
-        return $service->getMenuByRestaurantId($party->restaurant_id);
+        return MenubookResource::collection(
+            $service->getMenuByRestaurantId($party->restaurant_id)
+        )->collection;
     }
 }

--- a/app/Http/Controllers/MenubookController.php
+++ b/app/Http/Controllers/MenubookController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Party;
+use App\Services\MenuService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class MenubookController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:api');
+    }
+
+    /**
+     * 食べる人が滞在している店の全てのメニューを返す
+     */
+    public function index(MenuService $service)
+    {
+        /* @var Party $party */
+        $party = Auth::user();
+
+        return $service->getMenuByRestaurantId($party->restaurant_id);
+    }
+}

--- a/app/Http/Resources/MenubookResource.php
+++ b/app/Http/Resources/MenubookResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MenubookResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'restaurant_id' => $this->restaurant_id,
+            'name' => $this->name,
+            'price' => $this->price,
+            'image_url' => $this->image_url,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Services/MenuService.php
+++ b/app/Services/MenuService.php
@@ -51,4 +51,12 @@ class MenuService
             throw new ForbiddenException();
         }
     }
+
+    public function getMenuByRestaurantId(
+        int $restaurant_id
+    ) {
+        return Menu::query()
+            ->where('restaurant_id', $restaurant_id)
+            ->get();
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,3 +22,4 @@ Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll'])->mi
 Route::post('/menu', [\App\Http\Controllers\MenuController::class, 'store'])->middleware('auth.business');
 Route::delete('/menu', [\App\Http\Controllers\MenuController::class, 'delete'])->middleware('auth.business');
 Route::resource('/ordered_item', \App\Http\Controllers\OrderedItemController::class);
+Route::resource('/menubook', \App\Http\Controllers\MenubookController::class);

--- a/tests/Feature/MenubookTest.php
+++ b/tests/Feature/MenubookTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Menu;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\CustomerTestCase;
+use Tests\TestCase;
+
+class MenubookTest extends CustomerTestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * テスト成功：認証に失敗したため、401が返ってくる
+     */
+    public function test_get_認証失敗_401()
+    {
+        // 認証を切る
+        $this->withCredentials = false;
+
+        // GET
+        $this->getJson('/api/menubook')
+            ->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * テスト成功：食べる人が滞在している店のメニュー一覧が返ってくる&200が返ってくる
+     */
+    public function test_get_滞在している店のメニュー一覧が取得できる_200()
+    {
+        $menus = Menu::query()
+            ->where('restaurant_id', $this->party->restaurant_id)
+            ->get();
+
+        $this->get('/api/menubook')
+            ->assertStatus(Response::HTTP_OK)
+            ->assertSimilarJson($menus->jsonSerialize());
+    }
+}


### PR DESCRIPTION
### 実現したいこと
- 認証をかけて、関係ない人のリクエストは弾く
- `GET /api/menubook`で滞在している店のメニュー一覧を取得

### 実装内容
- `GET /api/menubook`で滞在している店のメニュー一覧を取得
- テスト
   - 認証情報がない時Forbidden
   - `GET /api/menubook`
      - 正しい内容の滞在している店のメニュー一覧を取得できる