### PR TITLE
order_check API: 店員さん用 注文の取得・追加・削除

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -42,10 +42,6 @@ class Handler extends ExceptionHandler
             //
         });
 
-//        $this->renderable(function (ForbiddenException $e) {
-//            throw new HttpException(Response::HTTP_FORBIDDEN);
-//        });
-
         $this->renderable(function (ForbiddenException $e) {
             return \response()->json([
                 'error' => $e->getMessage(),

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use App\Services\ForbiddenException;
+use App\Services\NotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -41,8 +42,20 @@ class Handler extends ExceptionHandler
             //
         });
 
+//        $this->renderable(function (ForbiddenException $e) {
+//            throw new HttpException(Response::HTTP_FORBIDDEN);
+//        });
+
         $this->renderable(function (ForbiddenException $e) {
-            throw new HttpException(Response::HTTP_FORBIDDEN);
+            return \response()->json([
+                'error' => $e->getMessage(),
+            ], Response::HTTP_FORBIDDEN);
+        });
+
+        $this->renderable(function (NotFoundException $e) {
+            return \response()->json([
+                'error' => $e->getMessage(),
+            ], Response::HTTP_NOT_FOUND);
         });
     }
 }

--- a/app/Http/Controllers/OrderCheckController.php
+++ b/app/Http/Controllers/OrderCheckController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CreateOrderByRestaurantRequest;
+use App\Http\Requests\CreateOrderRequest;
+use App\Http\Requests\DeleteOrderRequest;
+use App\Models\Restaurant;
+use App\Services\NotFoundException;
+use App\Services\OrderCheckService;
+use App\Services\OrderedItemService;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderCheckController extends Controller
+{
+    /**
+     * 店舗内の食べる人の注文一覧を返す
+     */
+    public function index(OrderCheckService $service)
+    {
+        // TODO: 店員さんの認証
+        $dummyRestaurantId = 1;
+        return $service->getOrderedByRestaurantId($dummyRestaurantId);
+    }
+
+//    /**
+//     * Show the form for creating a new resource.
+//     */
+//    public function create(CreateOrderByRestaurantRequest $request, OrderCheckService $service)
+//    {
+//        //
+//    }
+
+    /**
+     * 店舗内の食べる人に代わって注文を出す
+     */
+    public function store(CreateOrderByRestaurantRequest $request, OrderCheckService $service)
+    {
+        // TODO: 店員さんの認証
+        $dummyRestaurantId = 1;
+        $dummyRestaurant = Restaurant::query()->find($dummyRestaurantId);
+
+        // validate request
+        $validated = $request->validated();
+
+        try {
+            $orderedItemRecords = $service->addNewOrderedItems(
+                $dummyRestaurant,
+                $validated['party'],
+                $validated['menu_ids'],
+            );
+
+            return \response()->json($orderedItemRecords, Response::HTTP_CREATED);
+        } catch (NotFoundException $e) {
+            return \response()->json([
+                'error' => 'Some ordered item is not found.',
+            ], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+//    /**
+//     * Display the specified resource.
+//     *
+//     * @param int $id
+//     * @return \Illuminate\Http\Response
+//     */
+//    public function show($id)
+//    {
+//        //
+//    }
+//
+//    /**
+//     * Show the form for editing the specified resource.
+//     *
+//     * @param int $id
+//     * @return \Illuminate\Http\Response
+//     */
+//    public function edit($id)
+//    {
+//        //
+//    }
+//
+//    /**
+//     * Update the specified resource in storage.
+//     *
+//     * @param \Illuminate\Http\Request $request
+//     * @param int $id
+//     * @return \Illuminate\Http\Response
+//     */
+//    public function update(Request $request, $id)
+//    {
+//        //
+//    }
+//
+    /**
+     * 店舗内の食べる人が出した注文を削除する
+     */
+    public function delete(DeleteOrderRequest $request, OrderCheckService $service)
+    {
+        // TODO: 店員さんの認証
+        $dummyRestaurantId = 1;
+
+        // validate request
+        $validated = $request->validated();
+
+        return $service->deleteOrder($dummyRestaurantId, $validated['id']);
+    }
+}

--- a/app/Http/Controllers/OrderCheckController.php
+++ b/app/Http/Controllers/OrderCheckController.php
@@ -24,14 +24,6 @@ class OrderCheckController extends Controller
         return $service->getOrderedByRestaurantId($dummyRestaurantId);
     }
 
-//    /**
-//     * Show the form for creating a new resource.
-//     */
-//    public function create(CreateOrderByRestaurantRequest $request, OrderCheckService $service)
-//    {
-//        //
-//    }
-
     /**
      * 店舗内の食べる人に代わって注文を出す
      */
@@ -59,40 +51,6 @@ class OrderCheckController extends Controller
         }
     }
 
-//    /**
-//     * Display the specified resource.
-//     *
-//     * @param int $id
-//     * @return \Illuminate\Http\Response
-//     */
-//    public function show($id)
-//    {
-//        //
-//    }
-//
-//    /**
-//     * Show the form for editing the specified resource.
-//     *
-//     * @param int $id
-//     * @return \Illuminate\Http\Response
-//     */
-//    public function edit($id)
-//    {
-//        //
-//    }
-//
-//    /**
-//     * Update the specified resource in storage.
-//     *
-//     * @param \Illuminate\Http\Request $request
-//     * @param int $id
-//     * @return \Illuminate\Http\Response
-//     */
-//    public function update(Request $request, $id)
-//    {
-//        //
-//    }
-//
     /**
      * 店舗内の食べる人が出した注文を削除する
      */

--- a/app/Http/Requests/CreateOrderByRestaurantRequest.php
+++ b/app/Http/Requests/CreateOrderByRestaurantRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateOrderByRestaurantRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'party' => ['required','int','min:1'],
+            'menu_ids' => ['required','array'],
+            'menu_ids.*' => ['int','min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/DeleteOrderRequest.php
+++ b/app/Http/Requests/DeleteOrderRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteOrderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'id' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Models/PartyState.php
+++ b/app/Models/PartyState.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+class PartyState
+{
+    /**
+     * 初期状態
+     */
+    const Pending = 0;
+    /**
+     * 会計待ち
+     */
+    const AccountWaiting = 1;
+    /**
+     * 会計済み
+     */
+    const Accounted = 2;
+}

--- a/app/Services/OrderCheckService.php
+++ b/app/Services/OrderCheckService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Menu;
 use App\Models\OrderedItem;
 use App\Models\Party;
+use App\Models\PartyState;
 use App\Models\Restaurant;
 use Illuminate\Support\Facades\DB;
 
@@ -16,7 +17,7 @@ class OrderCheckService
     {
         $partyIds = Party::query()
             ->where('restaurant_id', $restaurantId)
-            ->where('state', 0)
+            ->where('state', PartyState::Pending)
             ->get()
             ->pluck('id');
         return OrderedItem::query()

--- a/app/Services/OrderCheckService.php
+++ b/app/Services/OrderCheckService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Menu;
+use App\Models\OrderedItem;
+use App\Models\Party;
+use App\Models\Restaurant;
+use Illuminate\Support\Facades\DB;
+
+class OrderCheckService
+{
+    public function getOrderedByRestaurantId(
+        int $restaurantId
+    )
+    {
+        $partyIds = Party::query()
+            ->where('restaurant_id', $restaurantId)
+            ->where('state', 0)
+            ->get()
+            ->pluck('id');
+        return OrderedItem::query()
+            ->whereIn('party_id', $partyIds)
+            ->get();
+    }
+
+    public function addNewOrderedItems(
+        Restaurant $restaurant,
+        int        $partyId,
+        array      $menuIds
+    )
+    {
+        // 自分の店以外のpartyへの注文は受けつけない
+        if (!Party::query()
+            ->where('id', $partyId)
+            ->where('restaurant_id', $restaurant->id)
+            ->exists()) {
+            throw new ForbiddenException("Forbidden party specified");
+        }
+
+        $orderedMenus = [];
+        foreach ($menuIds as $menuId) {
+            $menu = Menu::query()->find($menuId);
+
+            if (is_null($menu)) {
+                // 存在しないメニューが指定されていた時
+                throw new NotFoundException();
+            }
+
+            if ($menu->restaurant_id != $restaurant->id) {
+                // 他店のメニューが指定されていた時
+                throw new ForbiddenException("Forbidden menu specified");
+            }
+
+            array_push($orderedMenus, $menu);
+        }
+
+        $orderedMenuRecords = [];
+
+        foreach ($orderedMenus as $orderMenu) {
+            array_push(
+                $orderedMenuRecords,
+                OrderedItem::create([
+                    'party_id' => $partyId,
+                    'menu_id' => $orderMenu->id,
+                ])
+            );
+        }
+
+        return $orderedMenuRecords;
+    }
+
+    public function deleteOrder(
+        int $restaurantId,
+        int $orderId
+    ) {
+        $targetOrder = OrderedItem::query()->find($orderId);
+
+        if (is_null($targetOrder)) {
+            // 指定されたidを持つordered_itemがない時
+            throw new NotFoundException("The ordered item $orderId is not found.");
+        }
+
+        $party = Party::query()->find($targetOrder->party_id);
+
+        if ($party->restaurant_id === $restaurantId) {
+            $targetOrder->delete();
+            // 削除した注文のレコードを返す
+            return $targetOrder;
+        } else {
+            // 他店の食べる人の注文を削除しようとしていた時
+            throw new ForbiddenException("Forbidden party specified.");
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             RestaurantSeeder::class,
             PartySeeder::class,
             MenuSeeder::class,
+            OrderedItemSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PartySeeder.php
+++ b/database/seeders/PartySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use Faker\Provider\Uuid;
 use Illuminate\Database\Seeder;
 use App\Models\Party;
 
@@ -17,5 +18,18 @@ class PartySeeder extends Seeder
         Party::factory()
             ->count(3)
             ->create();
+
+        // テスト用に店舗id=1に滞在する食べる人が必ず存在するようにする
+        Party::create([
+            'restaurant_id' => 1,
+            'state' => 0,
+            'uuid' => Uuid::uuid(),
+        ]);
+        // テスト用に店舗id=2に滞在する食べる人が必ず存在するようにする
+        Party::create([
+            'restaurant_id' => 2,
+            'state' => 0,
+            'uuid' => Uuid::uuid(),
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,4 +22,7 @@ Route::get('/menu', [\App\Http\Controllers\MenuController::class, 'getAll'])->mi
 Route::post('/menu', [\App\Http\Controllers\MenuController::class, 'store'])->middleware('auth.business');
 Route::delete('/menu', [\App\Http\Controllers\MenuController::class, 'delete'])->middleware('auth.business');
 Route::resource('/ordered_item', \App\Http\Controllers\OrderedItemController::class);
+Route::get('/order_check', [\App\Http\Controllers\OrderCheckController::class, 'index']);
+Route::post('/order_check', [\App\Http\Controllers\OrderCheckController::class, 'store']);
+Route::delete('/order_check', [\App\Http\Controllers\OrderCheckController::class, 'delete']);
 Route::resource('/menubook', \App\Http\Controllers\MenubookController::class);

--- a/tests/Feature/OrderCheckTest.php
+++ b/tests/Feature/OrderCheckTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Menu;
+use App\Models\OrderedItem;
+use App\Models\Party;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
+use Nette\Utils\DateTime;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class OrderCheckTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * テスト成功：認証失敗、401が返ってくる
+     */
+    public function test_get_認証失敗_403()
+    {
+        // TODO 店員さんの認証
+        self::markTestIncomplete();
+
+        // GET
+        $this->getJson('/api/order_check')
+            ->assertStatus(Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * テスト成功：正しい内容の注文された品物一覧が取得できる&200が返ってくる
+     */
+    public function test_get_正しい内容の注文された品物一覧が取得できる_200()
+    {
+        $parties = Party::query()
+            ->where('restaurant_id', 1)
+            ->get();
+
+        $orders = OrderedItem::query()
+            ->whereIn('party_id', $parties->pluck('id'))
+            ->get();
+
+        $this->get('/api/order_check')
+            ->assertStatus(Response::HTTP_OK)
+            ->assertSimilarJson($orders->jsonSerialize());
+    }
+
+    /**
+     * テスト成功：POSTしたordered_itemのレコードが返ってくる&201が返ってくる
+     */
+    public function test_post_postしたordered_itemのレコードが返ってくる_201()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', 1)
+            ->first();
+        $menus = Menu::query()
+            ->where('restaurant_id', $party->restaurant_id)
+            ->take(3)
+            ->get();
+
+        $orderJSON = [
+            'party' => $party->id,
+            'menu_ids' => $menus->pluck('id'),
+        ];
+
+        $request = $this->postJson('/api/order_check', $orderJSON);
+
+        $orderedItems = OrderedItem::query()
+            ->where('party_id', $party->id)
+            ->whereIn('menu_id', $menus->pluck('id'))
+            ->latest('id')
+            ->take(count($menus->pluck('id')))
+            ->get();
+
+        $request->assertStatus(Response::HTTP_CREATED)
+            ->assertSimilarJson($orderedItems->jsonSerialize());
+    }
+
+    /**
+     * テスト成功：403が返ってくる
+     */
+    public function test_post_別の店舗のメニューを注文する_403()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', 1)
+            ->first();
+        $menus = Menu::query()
+            ->where('restaurant_id', '<>', $party->restaurant_id)
+            ->take(3)
+            ->get();
+
+        $orderJSON = [
+            'party' => $party->id,
+            'menu_ids' => $menus->pluck('id'),
+        ];
+
+        $this->postJson('/api/order_check', $orderJSON)
+            ->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * テスト成功：403が返ってくる
+     */
+    public function test_post_別の店舗の食べる人の注文を出す_403()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', '<>', 1)
+            ->first();
+
+        $menus = Menu::query()
+            ->where('restaurant_id', 1)
+            ->take(3)
+            ->get();
+
+        $orderJSON = [
+            'party' => $party->id,
+            'menu_ids' => $menus->pluck('id'),
+        ];
+
+        $this->postJson('/api/order_check', $orderJSON)
+            ->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * テスト成功：404が返ってくる
+     */
+    public function test_post_存在しないメニューの注文を試みる_404()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', 1)
+            ->first();
+
+        // 存在しないメニューを指定
+        $orderMenu = [
+            'party' => $party->id,
+            'menu_ids' => [20210917],
+        ];
+
+        $this->postJson('/api/order_check', $orderMenu)
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * テスト成功：422が返ってくる
+     */
+    public function test_post_バリデーション違反_メニュー注文失敗_422()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', 1)
+            ->first();
+
+        $order = [-1, -2];
+        $orderJSON = [
+            'party' => $party->id,
+            'menu_ids' => $order,
+        ];
+
+        $this->postJson('/api/order_check', $orderJSON)
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $order = [];
+        $orderJSON = [
+            'menu_ids' => $order,
+        ];
+
+        $this->postJson('/api/order_check', $orderJSON)
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * テスト成功：削除したordered_itemのレコードが返ってくる&200が返ってくる
+     */
+    public function test_delete_削除したordered_itemのレコードが返ってくる_200()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', 1)
+            ->first();
+        $ordered_item = OrderedItem::query()
+            ->where('party_id', $party->id)
+            ->first();
+
+        $deleteJSON = [
+            'id' => $ordered_item->id,
+        ];
+
+        $this->deleteJson('/api/order_check', $deleteJSON)
+            ->assertStatus(Response::HTTP_OK)
+            ->assertSimilarJson($ordered_item->jsonSerialize());
+    }
+
+    /**
+     * テスト成功：403が返ってくる
+     */
+    public function test_delete_別の店舗の食べる人の注文を消す_403()
+    {
+        $party = Party::query()
+            ->where('restaurant_id', '<>', 1)
+            ->first();
+        $ordered_item = OrderedItem::query()
+            ->where('party_id', $party->id)
+            ->first();
+
+        $deleteJSON = [
+            'id' => $ordered_item->id,
+        ];
+
+        $this->deleteJson('/api/order_check', $deleteJSON)
+            ->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * テスト成功：404が返ってくる
+     */
+    public function test_delete_存在しない注文を消す_404()
+    {
+        // 存在しない注文を指定
+        $deleteJSON = [
+            'id' => 20210921,
+        ];
+
+        $this->deleteJson('/api/order_check', $deleteJSON)
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * テスト成功：422が返ってくる
+     */
+    public function test_delete_バリデーション違反_422()
+    {
+        $deleteJSON = [
+            'id' => -1,
+        ];
+
+        $this->deleteJson('/api/order_check', $deleteJSON)
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/tests/Feature/OrderedItemTest.php
+++ b/tests/Feature/OrderedItemTest.php
@@ -59,19 +59,22 @@ class OrderedItemTest extends CustomerTestCase
     public function test_post_メニューを注文する_postしたordered_itemのレコードが返ってくる_201()
     {
         $restaurant = $this->party->restaurant_id;
-        $order = Menu::all()
+        $orderedMenu = Menu::all()
             ->where('restaurant_id', $restaurant)
             ->take(3);
 
-        $order = $order->pluck('id');
+        $orderedMenuIds = $orderedMenu->pluck('id');
+        var_dump($orderedMenuIds);
         $orderJSON = [
-            'menu_ids' => $order,
+            'menu_ids' => $orderedMenuIds,
         ];
 
         $request = $this->postJson('/api/ordered_item', $orderJSON);
 
         $orderedItems = OrderedItem::query()
-            ->whereIn('menu_id', $order)
+            ->whereIn('menu_id', $orderedMenuIds)
+            ->orderBy('id', 'desc')
+            ->take(count($orderedMenuIds))
             ->get();
 
         $request->assertStatus(Response::HTTP_CREATED)

--- a/tests/Feature/OrderedItemTest.php
+++ b/tests/Feature/OrderedItemTest.php
@@ -64,7 +64,6 @@ class OrderedItemTest extends CustomerTestCase
             ->take(3);
 
         $orderedMenuIds = $orderedMenu->pluck('id');
-        var_dump($orderedMenuIds);
         $orderJSON = [
             'menu_ids' => $orderedMenuIds,
         ];


### PR DESCRIPTION
### 実現したいこと
- 認証をかけて、関係ない人のリクエストは弾く
- `GET /order_check`で、お店に滞在している食べる人たちの注文の一覧を取得する
- `POST /order_check`で、お店に滞在している食べる人たちに代わって、注文を出す
- `DELETE /order_check`で、お店に滞在している食べる人たちの出した注文を、1件消す

### 実装内容
- `GET /order_check`で、お店に滞在している食べる人たちが注文した品物の一覧を取得する
- `POST /order_check`で、お店に滞在している食べる人たちに代わって、注文を出す
   - 追加された注文のレコード（配列）が返ってくる
- `DELETE /order_check`で、お店に滞在している食べる人たちが注文品物を、1件消す
   - 削除された注文のレコードが返ってくる
- テスト
   - `GET /order_check`
      -  正しい内容の注文された品物一覧が取得できる
   - `POST /order_check`
      - 正しいリクエスト -> 注文したordered itemのレコード（配列）が返ってくる / 201
      - 別の店舗のメニューを注文するリクエスト -> 403
      - 別の店舗の食べる人に変わって注文を出すリクエスト -> 403
      - 存在しないメニューを注文するリクエスト -> 404
      - バリデーション違反 -> 422
   - `DELETE /order_check`
      - 正しいリクエスト -> 削除したordered_itemのレコードが返ってくる / 200
      - 別の店舗の食べる人の注文を消すリクエスト -> 403
      - 存在しない注文を消すリクエスト -> 404
      - バリデーション違反 -> 422

### 未実装の内容
- 店員さんの認証